### PR TITLE
Add container image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         items:
-          - build-args: SWIFT_IMAGE=swift:5.9-jammy
+          - file: docker/5.9/amd64/Dockerfile
             platform: linux/amd64
-          - build-args: SWIFT_IMAGE=swift:5.9-jammy
+          - file: docker/5.9/arm64/Dockerfile
             platform: linux/arm64
 
     permissions:
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.items.platform }}
-          build-args: ${{ matrix.items.build-args }}
+          file: ${{ matrix.items.file }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -2,7 +2,7 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['master', 'add-container-image']
+    branches: ['master']
     tags: ['v*']
 
 env:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-contexts:
+        build-arg:
           - SWIFT_IMAGE=swift:5.9-jammy
           - SWIFT_IMAGE=arm64v8/swift:5.9-jammy
         platform:
@@ -57,7 +57,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
-          build-contexts: ${{ matrix.build-contexts }}
+          build-arg: ${{ matrix.build-arg }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.items.platform }}
-          build-arg: ${{ matrix.items.build-arg }}
+          build-args: ${{ matrix.items.build-arg }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,12 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-arg:
-          - SWIFT_IMAGE=swift:5.9-jammy
-          - SWIFT_IMAGE=arm64v8/swift:5.9-jammy
-        platform:
-          - linux/amd64
-          - linux/arm64
+        items:
+          - build-arg: SWIFT_IMAGE=swift:5.9-jammy
+            platform: linux/amd64
+          - build-arg: SWIFT_IMAGE=arm64v8/swift:5.9-jammy
+            platform: linux/arm64
 
     permissions:
       contents: read
@@ -56,8 +55,8 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          platforms: ${{ matrix.platform }}
-          build-arg: ${{ matrix.build-arg }}
+          platforms: ${{ matrix.items.platform }}
+          build-arg: ${{ matrix.items.build-arg }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -69,7 +68,6 @@ jobs:
           channel-id: ${{ env.CHANNEL_ID }}
           payload: |
             {
-              "text": "Build and push Docker image succeeded",
               "blocks": [
                 {
                   "type": "header",

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         items:
-          - build-arg: SWIFT_IMAGE=swift:5.9-jammy
+          - build-args: SWIFT_IMAGE=swift:5.9-jammy
             platform: linux/amd64
-          - build-arg: SWIFT_IMAGE=arm64v8/swift:5.9-jammy
+          - build-args: SWIFT_IMAGE=swift:5.9-jammy
             platform: linux/arm64
 
     permissions:
@@ -56,7 +56,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.items.platform }}
-          build-args: ${{ matrix.items.build-arg }}
+          build-args: ${{ matrix.items.build-args }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -17,10 +17,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        build-contexts:
+          - SWIFT_IMAGE=swift:5.9-jammy
+          - SWIFT_IMAGE=arm64v8/swift:5.9-jammy
         platform:
           - linux/amd64
           - linux/arm64
-          - darwin/amd64
 
     permissions:
       contents: read
@@ -55,6 +57,7 @@ jobs:
         with:
           context: .
           platforms: ${{ matrix.platform }}
+          build-contexts: ${{ matrix.build-contexts }}
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -72,7 +75,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "A new Docker ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} image  was built and deployed\n${{ steps.build_and_push_docker_image.outputs }}"
+                    "text": "A new Docker image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} was built and deployed\n${{ steps.build_and_push_docker_image.outputs }}"
                   }
                 }
               ]

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -30,6 +30,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -85,3 +85,29 @@ jobs:
                 }
               ]
             }
+
+      - name: Send a failure message on Slack channel
+        id: slack_failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ env.CHANNEL_ID }}
+          payload: |
+              {
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "Failed to build Docker image :bangbang:"
+                    }
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "Failed to build ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}"
+                    }
+                  }
+                ]
+              }

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -72,10 +72,17 @@ jobs:
               "text": "Build and push Docker image succeeded",
               "blocks": [
                 {
+                  "type": "header",
+                  "text": {
+                    "type": "plain_text",
+                    "text": "New Docker image 🤖"
+                  }
+                },
+                {
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "A new Docker image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} was built and deployed\n${{ steps.build_and_push_docker_image.outputs }}"
+                    "text": "An image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} was built and deployed\n${{ toJson(steps.build_and_push_docker_image.outputs) }}"
                   }
                 }
               ]

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,7 +80,7 @@ jobs:
                   "type": "section",
                   "text": {
                     "type": "mrkdwn",
-                    "text": "An image ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} was built and deployed\n${{ toJson(steps.build_and_push_docker_image.outputs) }}"
+                    "text": "An image ${{ env.DOCKER_METADATA_OUTPUT_TAGS }} was built and deployed"
                   }
                 }
               ]

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,73 @@
+name: Create and publish a Docker image
+
+on:
+  push:
+    branches: ['master', 'add-container-image']
+    tags: ['v*']
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+  CHANNEL_ID: ${{ vars.SLACK_CHANNEL_ID }}
+
+jobs:
+  build-and-push-image:
+    runs-on: ubuntu-22.04
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - darwin/amd64
+
+    permissions:
+      contents: read
+      packages: write
+      
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        id: build_and_push_docker_image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: Send a message on Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.24.0
+        with:
+          channel-id: ${{ env.CHANNEL_ID }}
+          payload: |
+            {
+              "text": "Build and push Docker image succeeded",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "A new Docker ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} image  was built and deployed\n${{ steps.build_and_push_docker_image.outputs }}"
+                  }
+                }
+              ]
+            }

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM swift:5.9-jammy
+ARG SWIFT_IMAGE=swift:5.9-jammy
+FROM $SWIFT_IMAGE
 
 RUN mkdir /workspace
 WORKDIR /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SWIFT_IMAGE=swift:5.9-jammy
+ARG SWIFT_IMAGE
 FROM $SWIFT_IMAGE
 
 RUN mkdir /workspace

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM swift:5.9-jammy
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN swift build -c release --static-swift-stdlib
+
+RUN cp /workspace/.build/release/swaggen /
+
+ENTRYPOINT [ "/swaggen" ]

--- a/docker/5.9/amd64/Dockerfile
+++ b/docker/5.9/amd64/Dockerfile
@@ -1,0 +1,12 @@
+FROM swift:5.9-jammy
+
+RUN mkdir /workspace
+WORKDIR /workspace
+
+COPY . /workspace
+
+RUN swift build -c release --static-swift-stdlib
+
+RUN cp /workspace/.build/release/swaggen /
+
+ENTRYPOINT [ "/swaggen" ]

--- a/docker/5.9/arm64/Dockerfile
+++ b/docker/5.9/arm64/Dockerfile
@@ -1,12 +1,11 @@
-ARG SWIFT_IMAGE
-FROM $SWIFT_IMAGE
+FROM arm64v8/swift:5.9-jammy
 
 RUN mkdir /workspace
 WORKDIR /workspace
 
 COPY . /workspace
 
-RUN swift build -c release --static-swift-stdlib
+RUN swift build -c release
 
 RUN cp /workspace/.build/release/swaggen /
 


### PR DESCRIPTION
Create two Docker images in different platforms.

Usage:

```
$ docker run -it ghcr.io/golface/swaggen:add-container-image swagger version
```

The `add-container-image` is this branch.